### PR TITLE
Allow specifying capabilities when creating a cf stack

### DIFF
--- a/lib/kitchen/driver/CloudFormation.rb
+++ b/lib/kitchen/driver/CloudFormation.rb
@@ -39,6 +39,7 @@ module Kitchen
       default_config :ssl_cert_file,      ENV['SSL_CERT_FILE']
       default_config :stack_name,         nil
       default_config :template_file,      nil
+      default_config :capabilities,      nil
       default_config :parameters,         {}
       default_config :disable_rollback,   false
       default_config :timeout_in_minutes, 0

--- a/lib/kitchen/driver/aws/stack_generator.rb
+++ b/lib/kitchen/driver/aws/stack_generator.rb
@@ -39,6 +39,7 @@ module Kitchen
           if config[:template_file]
             s[:template_body] = File.open(config[:template_file], 'rb') { |file| file.read }
           end
+	  s[:capabilities] = config[:capabilities] if !config[:capabilities].nil? && (config[:capabilities].is_a? Array)
           s[:timeout_in_minutes] = config[:timeout_in_minutes] if !config[:timeout_in_minutes].nil? && config[:timeout_in_minutes] > 0
           s[:disable_rollback] = config[:disable_rollback]     if !config[:disable_rollback].nil? && config[:disable_rollback] == true || config[:disable_rollback] == false
           s[:parameters] = []


### PR DESCRIPTION
as per documentation:
--capabilities (list)
          A list of capabilities that you must specify before AWS  CloudForma-
          tion can create or update certain stacks. Some stack templates might
          include resources that can affect permissions in your  AWS  account.
          For those stacks, you must explicitly acknowledge their capabilities
          by specifying this parameter.
