### PR TITLE
Update stack_generator.rb

### DIFF
--- a/lib/kitchen/driver/aws/stack_generator.rb
+++ b/lib/kitchen/driver/aws/stack_generator.rb
@@ -34,7 +34,7 @@ module Kitchen
         # can be passed in null, others need to be ommitted if they are null
         def cf_stack_data
           s = { stack_name: config[:stack_name] }
-          s[:template_url] = config[:template_url] if config[:template_file]
+          s[:template_url] = config[:template_url] if config[:template_file].nil?
           if config[:template_file]
             s[:template_body] = File.open(config[:template_file], 'rb') { |file| file.read }
           end


### PR DESCRIPTION
Provisioning with the template_url configuration option is not working. jLine 37 was missing logic that was not allowing the template_url config option to be populated.